### PR TITLE
Add .gitignore and .gitattributes for repo hygiene. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,14 @@
 /.editorconfig       export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
+/phpunit.xml         export-ignore
 /phpunit.xml.dist    export-ignore
+/phpstan.neon        export-ignore
 /phpstan.neon.dist   export-ignore
+/phpcs.xml           export-ignore
 /phpcs.xml.dist      export-ignore
 /infection.json      export-ignore
+/infection.json.dist export-ignore
 /Makefile            export-ignore
 /CONTRIBUTING.md     export-ignore
 /CHANGES.md          export-ignore


### PR DESCRIPTION
Prevent agent/IDE folders (.claude, .idea, .vscode) from being versioned and exclude dev-only files (tests, phpstan, phpcs, phpunit configs) from the Packagist tarball via export-ignore.